### PR TITLE
Potential fix for code scanning alert no. 25: Clear-text logging of sensitive information

### DIFF
--- a/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
+++ b/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
@@ -203,7 +203,9 @@ class ApiKeyHelper(object):
         log.info("%s starting" % logPrefix)
 
         login_params = { 'command': 'login', 'username': 'admin', 'password': password, 'response': 'json' }
-        log.info("%s login_params=%s" % (logPrefix, login_params))
+        safe_login_params = login_params.copy()
+        safe_login_params['password'] = '***'
+        log.info("%s login_params=%s" % (logPrefix, safe_login_params))
 
         # # create sessionkey and cookie of the api session initiated with username and password
         session = requests.Session()


### PR DESCRIPTION
Potential fix for [https://github.com/lj020326/ansible-datacenter/security/code-scanning/25](https://github.com/lj020326/ansible-datacenter/security/code-scanning/25)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged. Instead of logging the entire `login_params` dictionary, we can log only the non-sensitive parts of it. We can create a copy of the dictionary with the password removed or masked before logging it.

- Identify the log statement that logs sensitive information.
- Create a copy of the `login_params` dictionary with the password removed or masked.
- Log the modified dictionary instead of the original one.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
