### PR TITLE
Potential fix for code scanning alert no. 24: Clear-text logging of sensitive information

### DIFF
--- a/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
+++ b/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
@@ -176,7 +176,8 @@ class ApiKeyHelper(object):
     def keys_valid(self, new_resource):
         logPrefix="keys_valid():"
         log.info("%s starting" % logPrefix)
-        log.debug("%s new_resource=%s" % (logPrefix, new_resource))
+        sanitized_resource = {k: (v if k != 'password' else '***') for k, v in new_resource.items()}
+        log.debug("%s new_resource=%s" % (logPrefix, sanitized_resource))
         # Test if current defined keys are valid
         #
         if ('admin_apikey' in new_resource or 'admin_secretkey' in new_resource):


### PR DESCRIPTION
Potential fix for [https://github.com/lj020326/ansible-datacenter/security/code-scanning/24](https://github.com/lj020326/ansible-datacenter/security/code-scanning/24)

To fix the issue, we need to ensure that sensitive data, such as passwords, is not logged. This can be achieved by sanitizing the `new_resource` object before logging it. Specifically, we should remove or mask sensitive fields like `password` from the object before passing it to the logging function. Additionally, we should review other logging statements in the codebase to ensure no sensitive data is inadvertently logged.

The fix involves:
1. Identifying sensitive fields in the `new_resource` object (e.g., `password`).
2. Creating a sanitized version of the object by removing or masking these fields.
3. Logging the sanitized object instead of the original `new_resource`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
