### PR TITLE
Potential fix for code scanning alert no. 23: Clear-text logging of sensitive information

### DIFF
--- a/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
+++ b/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
@@ -123,7 +123,8 @@ class ApiKeyHelper(object):
                 log.info('%s keys not found' % logPrefix)
                 log.info('%s Creating keys for admin' % logPrefix)
                 admin_keys = self.generate_admin_keys(resource['password'])
-                log.info('%s admin api keys: Generated new key admin_keys=%s' % (logPrefix, admin_keys))
+                redacted_admin_keys = {key: "<REDACTED>" if key in ["api_key", "secret_key"] else value for key, value in admin_keys.items()}
+                log.info('%s admin api keys: Generated new key admin_keys=%s' % (logPrefix, redacted_admin_keys))
             else:
                 log.info('%s admin api keys: use existing in CloudStack' % logPrefix)
 


### PR DESCRIPTION
Potential fix for [https://github.com/lj020326/ansible-datacenter/security/code-scanning/23](https://github.com/lj020326/ansible-datacenter/security/code-scanning/23)

To fix the issue, we will remove the sensitive data from the log messages. Instead of logging the entire `admin_keys` dictionary, we will log only non-sensitive information or redact the sensitive fields (`api_key` and `secret_key`) before logging. This ensures that sensitive data is not exposed in the logs while still providing useful debugging information.

Specifically:
1. Replace the log statement on line 126 to exclude sensitive data.
2. Use a redacted version of the `admin_keys` dictionary for logging purposes, replacing the sensitive values with placeholders like `"<REDACTED>"`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
