### PR TITLE
Potential fix for code scanning alert no. 21: Clear-text logging of sensitive information

### DIFF
--- a/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
+++ b/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
@@ -111,7 +111,8 @@ class ApiKeyHelper(object):
         new_resource = resource
         logPrefix="admin_apikeys_from_cloudstack():"
         log.info("%s starting" % logPrefix)
-        log.debug("%s resource=%s" % (logPrefix, resource))
+        sanitized_resource = {k: (v if k != 'password' else '<redacted>') for k, v in resource.items()}
+        log.debug("%s resource=%s" % (logPrefix, sanitized_resource))
 
         # look if apikeys already exist
         # otherwise  generate them


### PR DESCRIPTION
Potential fix for [https://github.com/lj020326/ansible-datacenter/security/code-scanning/21](https://github.com/lj020326/ansible-datacenter/security/code-scanning/21)

To fix the issue, we need to ensure that sensitive information such as passwords is not logged. The best approach is to sanitize the `resource` dictionary before logging it. Specifically, we should redact or remove sensitive fields like `password` before including the dictionary in log messages. This can be achieved by creating a sanitized copy of the `resource` dictionary with sensitive fields removed or replaced with placeholder values (e.g., `"<redacted>"`).

The fix involves:
1. Creating a sanitized version of the `resource` dictionary by excluding or redacting sensitive fields.
2. Logging the sanitized dictionary instead of the original `resource` dictionary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
