### PR TITLE
Potential fix for code scanning alert no. 20: Clear-text logging of sensitive information

### DIFF
--- a/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
+++ b/roles/bootstrap_cloudstack_controller/files/cs-utils/cs-utils.py
@@ -80,8 +80,9 @@ class ApiKeyHelper(object):
             if new_resource.username == 'admin':
                 log.info('Reseting admin api keys')
                 admin_keys = self.generate_admin_keys(new_resource.url, new_resource.password)
-                log.info('admin api keys: Generate new admin keys admin_keys=[%s]' % admin_keys)
-
+                sanitized_admin_keys = admin_keys.copy()
+                sanitized_admin_keys['secret_key'] = '***REDACTED***'
+                log.info('admin api keys: Generate new admin keys admin_keys=[%s]' % sanitized_admin_keys)
                 new_resource.admin_apikey = admin_keys['api_key']
                 new_resource.admin_secretkey = admin_keys['secret_key']
         else:


### PR DESCRIPTION
Potential fix for [https://github.com/lj020326/ansible-datacenter/security/code-scanning/20](https://github.com/lj020326/ansible-datacenter/security/code-scanning/20)

To fix the issue, we need to ensure that sensitive data such as `secret_key` is not logged in plaintext. Instead of logging the entire `admin_keys` dictionary, we can redact or mask the sensitive fields (e.g., replace the `secret_key` with a placeholder like `***REDACTED***`). This approach retains the ability to log non-sensitive information for debugging purposes while protecting sensitive data.

Steps to implement the fix:
1. Modify the log statement on line 83 to redact the `secret_key` field from `admin_keys` before logging.
2. Create a sanitized version of the `admin_keys` dictionary where the `secret_key` is replaced with a placeholder.
3. Log the sanitized dictionary instead of the original `admin_keys`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
